### PR TITLE
Nice err if recovery costs too much gas for signer

### DIFF
--- a/src/components/DBRecoveryList.js
+++ b/src/components/DBRecoveryList.js
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from 'react'
+import { Stack } from '@mui/material'
+import axios from 'axios'
+import { RecoveryRequestCard } from './RecoveryRequestCard'
+import { getSocialModuleInstance } from '../utils/contractSource'
+import { useConnectWallet } from '@web3-onboard/react'
+import { ethers } from 'ethers'
+
+let provider
+
+export const DBRecoveryList = props => {
+  const {
+    toAddress,
+    setLoadingActive,
+    setSnackBarMessage,
+    setOpenSnackBar,
+    readyToTransact
+  } = props
+  const [, setFetchingRequests] = useState(false)
+  const [recoveryRequests, setRecoveryRequests] = useState([])
+  const [minimumSignatures, setMinimumSignatures] = useState(0)
+
+  const [{ wallet }] = useConnectWallet()
+
+  useEffect(() => {
+    if (!wallet?.provider) {
+      provider = null
+    } else {
+      provider = new ethers.providers.Web3Provider(wallet.provider, 'any')
+    }
+  }, [wallet])
+
+  const showFetchingError = errorMessage => {
+    setFetchingRequests(false)
+    setOpenSnackBar(true)
+    setSnackBarMessage(errorMessage)
+  }
+
+  const fetchRecoveryRequests = async () => {
+    setRecoveryRequests([])
+    setFetchingRequests(true)
+    const response = await axios.get(
+      `${process.env.REACT_APP_SECURITY_URL}/v1/guardian/fetchByAddress`,
+      { params: { walletAddress: toAddress.toLowerCase(), network: 'Goerli' } }
+    )
+    console.log(response.data)
+    if (response.data.length === 0) {
+      showFetchingError(`No recovery requests found for ${toAddress}`)
+      return
+    }
+    //
+    let guardians = []
+    let minimumSignatures = 0
+    if (provider == null) return // not ready to interact with chain
+    try {
+      const lostWallet = await getSocialModuleInstance(
+        response.data[0].socialRecoveryAddress,
+        provider
+      )
+      guardians = await lostWallet.getFriends()
+      guardians = guardians.map(element => {
+        return element.toLowerCase()
+      })
+      console.log(guardians)
+      //
+      minimumSignatures = (await lostWallet.threshold()).toNumber()
+      //
+    } catch (e) {
+      console.error(e)
+      showFetchingError('Unable to check request status')
+      return
+    }
+    const signer = provider.getUncheckedSigner()
+    const signerAddress = (await signer.getAddress()).toLowerCase()
+    console.log(signerAddress.toLowerCase())
+    console.log(guardians[0])
+    console.log(typeof guardians[0])
+    if (!guardians.includes(signerAddress.toLowerCase())) {
+      showFetchingError('You are not a guardian for this wallet')
+      return
+    }
+    //
+    setMinimumSignatures(minimumSignatures)
+    setRecoveryRequests(response.data)
+    setFetchingRequests(false)
+  }
+
+  useEffect(() => {
+    fetchRecoveryRequests()
+  }, [toAddress])
+
+  return (
+    <Stack>
+      {recoveryRequests.map((object, i) => (
+        <RecoveryRequestCard
+          request={object}
+          key={object.id}
+          minimumSignatures={minimumSignatures}
+          showFetchingError={showFetchingError}
+          fetchRecoveryRequests={fetchRecoveryRequests}
+          setLoadingActive={setLoadingActive}
+          setSnackBarMessage={setSnackBarMessage}
+          setOpenSnackBar={setOpenSnackBar}
+          readyToTransact={readyToTransact}
+        />
+      ))}
+    </Stack>
+  )
+}

--- a/src/components/RecoveryRequestCard.js
+++ b/src/components/RecoveryRequestCard.js
@@ -1,59 +1,228 @@
-import React from 'react';
-import { Button, Card, CardActions, CardContent, Typography } from "@mui/material";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSignature, faBolt } from "@fortawesome/free-solid-svg-icons";
+import React, { useEffect, useState } from 'react'
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Typography
+} from '@mui/material'
+import axios from 'axios'
+import { useConnectWallet } from '@web3-onboard/react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSignature, faBolt, faBan } from '@fortawesome/free-solid-svg-icons'
+import { ethers } from 'ethers'
+import { getSocialModuleInstance } from '../utils/contractSource'
 
-export const RecoveryRequestCard = (props) => {
-  const dateFormat = new Intl.DateTimeFormat('en-GB', { dateStyle: 'full', timeStyle: 'long' });
+let provider
 
-  const { request, minimumSignatures, onClickSign } = props;
+export const RecoveryRequestCard = props => {
+  const dateFormat = new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'full',
+    timeStyle: 'long'
+  })
+  const {
+    request,
+    minimumSignatures,
+    fetchRecoveryRequests,
+    showFetchingError,
+    setLoadingActive,
+    setSnackBarMessage,
+    setOpenSnackBar,
+    readyToTransact
+  } = props
+  const [{ wallet }] = useConnectWallet()
+
+  const [insufficientBalance, setInsufficientBalance] = useState(false)
+
+  useEffect(() => {
+    if (!wallet?.provider) {
+      provider = null
+    } else {
+      provider = new ethers.providers.Web3Provider(wallet.provider, 'any')
+    }
+    setInsufficientBalance(false)
+  }, [wallet])
+
+  const signDataHash = async (dataHash, id) => {
+    const signer = provider.getUncheckedSigner()
+    let result = null
+    try {
+      result = await signer.signMessage(ethers.utils.arrayify(dataHash))
+    } catch (e) {
+      return null
+    }
+    setLoadingActive(true)
+    try {
+      await axios.post(
+        `${process.env.REACT_APP_SECURITY_URL}/v1/guardian/sign`,
+        {
+          id,
+          signedMessage: result
+        }
+      )
+      await fetchRecoveryRequests()
+      setLoadingActive(false)
+    } catch (e) {
+      setLoadingActive(false)
+      showFetchingError('Error occurred while submitting signature')
+      return null
+    }
+    return result
+  }
+
+  const onClickSign = async () => {
+    const ready = await readyToTransact()
+    if (!ready) return
+    try {
+      const result = await signDataHash(request.dataHash, request.id)
+      console.log(result)
+    } catch (e) {
+      setSnackBarMessage('User cancelled signing operation')
+      setOpenSnackBar(true)
+      return
+    }
+  }
+
+  const submitRecovery = async (
+    id,
+    socialRecoveryAddress,
+    oldOwner,
+    newOwner,
+    signatures
+  ) => {
+    const signer = provider.getUncheckedSigner()
+    let transaction = {
+      to: socialRecoveryAddress,
+      value: 0,
+      gasLimit: 168463 * 2
+    }
+    let result = null
+    setLoadingActive(true)
+    try {
+      const lostWallet = await getSocialModuleInstance(
+        socialRecoveryAddress,
+        provider
+      )
+      let callData = lostWallet.interface.encodeFunctionData(
+        'confirmAndRecoverAccess',
+        [
+          '0x0000000000000000000000000000000000000001',
+          oldOwner,
+          newOwner,
+          signatures
+        ]
+      )
+      transaction.data = callData
+      result = await signer.sendTransaction(transaction)
+      await axios.post(
+        `${process.env.REACT_APP_SECURITY_URL}/v1/guardian/submit`,
+        { id, transactionHash: result.hash }
+      )
+      await fetchRecoveryRequests()
+      setLoadingActive(false)
+    } catch (e) {
+      if (e.code === 'INSUFFICIENT_FUNDS') setInsufficientBalance(true)
+      setLoadingActive(false)
+      showFetchingError('Error occurred while submitting recovery request')
+      return null
+    }
+    return result
+  }
+
+  const onClickSubmit = async () => {
+    const ready = await readyToTransact()
+    if (!ready) return
+    try {
+      const result = await submitRecovery(
+        request.id,
+        request.socialRecoveryAddress,
+        request.oldOwner,
+        request.newOwner,
+        request.signatures
+      )
+      console.log(result)
+    } catch (e) {
+      setSnackBarMessage('User cancelled submit operation')
+      setOpenSnackBar(true)
+      return
+    }
+  }
 
   return (
-    <Card variant="outlined" style={{
-      background: "#1F2546",
-      borderRadius: "15px",
-      margin: "10px",
-    }} width={"100%"} centered>
+    <Card
+      variant="outlined"
+      style={{
+        background: '#1F2546',
+        borderRadius: '15px',
+        margin: '10px'
+      }}
+      width={'100%'}
+    >
       <CardContent>
-        <Typography sx={{ fontSize: 14, fontFamily: "Gilroy" }} color="#F8ECE1" gutterBottom>
+        <Typography
+          sx={{ fontSize: 14, fontFamily: 'Gilroy' }}
+          color="#F8ECE1"
+          gutterBottom
+        >
           Created {dateFormat.format(Date.parse(request.createdAt))}
         </Typography>
-        <Typography variant='h6' noWrap color="#F8ECE1">
+        <Typography variant="h6" noWrap color="#F8ECE1">
           {request.walletAddress}
         </Typography>
-        <Typography sx={{ mb: 1.5, fontFamily: "Gilroy" }} color="#F8ECE1">
-          Collected {request.signaturesAcquired ?? "0"} out of {minimumSignatures ?? "1"} minimum signatures
+        <Typography sx={{ mb: 1.5, fontFamily: 'Gilroy' }} color="#F8ECE1">
+          Collected {request.signaturesAcquired ?? '0'} out of{' '}
+          {minimumSignatures ?? '1'} minimum signatures
         </Typography>
-        <Typography sx={{ mb: 1.5, fontFamily: "Gilroy" }} color="#F8ECE1">
+        <Typography sx={{ mb: 1.5, fontFamily: 'Gilroy' }} color="#F8ECE1">
           {request.signaturesAcquired !== minimumSignatures
             ? "Only sign if these emojis match those on the owner's screen"
-            : "All signatures have been collected! You now need to submit this transaction to recover the account."
-          }
+            : 'All signatures have been collected! You now need to submit this transaction to recover the account.'}
         </Typography>
         <Typography variant={'h5'} sx={{ mb: 1.5 }}>
           {request.emoji}
         </Typography>
       </CardContent>
       <CardActions sx={{ mr: 5 }}>
-        <Button
-          variant="contained"
-          style={{
-            background: "#F8ECE1",
-            padding: "0.55rem 1.4rem",
-            color: "#1F2546",
-          }}
-          startIcon={
-            request.signaturesAcquired !== minimumSignatures
-              ? (
-                <FontAwesomeIcon icon={faSignature} />
-              ) : (
-                <FontAwesomeIcon icon={faBolt} />
-              )
-          }
-          onClick={onClickSign}
-        >
-          {request.signaturesAcquired !== minimumSignatures ? "Sign" : "Submit"}
-        </Button>
+        {request.signaturesAcquired !== minimumSignatures ? (
+          <Button
+            variant="contained"
+            style={{
+              background: '#F8ECE1',
+              padding: '0.55rem 1.4rem',
+              color: '#1F2546'
+            }}
+            startIcon={<FontAwesomeIcon icon={faSignature} />}
+            onClick={onClickSign}
+          >
+            Sign
+          </Button>
+        ) : insufficientBalance ? (
+          <Button
+            variant="contained"
+            disabled
+            style={{
+              background: '#F8ECE1',
+              padding: '0.55rem 1.4rem',
+              color: '#1F2546'
+            }}
+            startIcon={<FontAwesomeIcon icon={faBan} />}
+          >
+            Insufficient Balance
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            style={{
+              background: '#F8ECE1',
+              padding: '0.55rem 1.4rem',
+              color: '#1F2546'
+            }}
+            startIcon={<FontAwesomeIcon icon={faBolt} />}
+            onClick={onClickSubmit}
+          >
+            Submit
+          </Button>
+        )}
       </CardActions>
     </Card>
   )

--- a/src/components/RecoveryRequestCard.js
+++ b/src/components/RecoveryRequestCard.js
@@ -121,9 +121,16 @@ export const RecoveryRequestCard = props => {
       await fetchRecoveryRequests()
       setLoadingActive(false)
     } catch (e) {
-      if (e.code === 'INSUFFICIENT_FUNDS') setInsufficientBalance(true)
+      if (e.code === 'INSUFFICIENT_FUNDS') {
+        setInsufficientBalance(true)
+        const estimatedCost = (await signer.getGasPrice()).mul(transaction.gasLimit)
+        setSnackBarMessage(`Insufficient balance to cover networks fees. Required: ${ethers.utils.formatEther(estimatedCost)} ETH`);
+        setOpenSnackBar(true);
+      }
+      else {
+        showFetchingError('Error occurred while submitting recovery request')
+      }
       setLoadingActive(false)
-      showFetchingError('Error occurred while submitting recovery request')
       return null
     }
     return result

--- a/src/services.js
+++ b/src/services.js
@@ -1,6 +1,5 @@
 import logo from './icons/logo.png'
 
-
 import { init } from '@web3-onboard/react'
 import injectedModule from '@web3-onboard/injected-wallets'
 import magicModule from '@web3-onboard/magic'
@@ -14,42 +13,36 @@ const coinbase = coinbaseModule()
 const walletConnect = walletConnectModule()
 const magic = magicModule({
   // public API key
-  apiKey: process.env.REACT_APP_MAGIC_LINK_PK,
+  apiKey: process.env.REACT_APP_MAGIC_LINK_PK
 })
 
-
 export const initWeb3Onboard = init({
-  wallets: [
-    injected,
-    walletConnect,
-    coinbase,
-    magic,
-  ],
+  wallets: [injected, walletConnect, coinbase, magic],
   chains: [
     {
       id: '0x5',
       token: 'gETH',
       label: 'Gorli',
-      rpcUrl: process.env.REACT_APP_GOERLI_RPC,
-    },
+      rpcUrl: process.env.REACT_APP_GOERLI_RPC
+    }
   ],
   appMetadata: {
     name: 'Candide Security',
     icon: logo,
     logo: logo,
-    description: 'Wallet Recovery',
+    description: 'Wallet Recovery'
   },
   accountCenter: {
     desktop: {
-      position: 'topRight',
+      position: 'bottomRight',
       enabled: true,
       minimal: false
     },
     mobile: {
       position: 'bottomRight',
       enabled: true,
-      minimal: true,
-    },
+      minimal: true
+    }
   },
   apiKey: dappId,
   notify: {
@@ -59,6 +52,7 @@ export const initWeb3Onboard = init({
         return {
           // autoDismiss set to zero will persist the notification until the user excuses it
           autoDismiss: 0,
+          // TODO: ensure we set up the proper block explorers for each chain
           onClick: () =>
             window.open(`https://goerli.etherscan.io/tx/${transaction.hash}`)
         }


### PR DESCRIPTION
This is the most minimal change that addresses #8 using the fixed gasLimit provided.

It could also be done by simulating the tx to check gas & signer balance as soon as the signature threshold gets crossed, so that the UI can better reflect that the submit won't work *before* the user attempts to.